### PR TITLE
Do not allow user to press send button if form is not valid. 

### DIFF
--- a/src/gui/static/karma.conf.js
+++ b/src/gui/static/karma.conf.js
@@ -4,12 +4,13 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', '@angular/cli'],
+    frameworks: ['jasmine', '@angular/cli', 'sinon'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sinon'),
       require('@angular/cli/plugins/karma')
     ],
     client:{

--- a/src/gui/static/package.json
+++ b/src/gui/static/package.json
@@ -46,7 +46,9 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-sinon": "1.0.5",
     "protractor": "~5.1.2",
+    "sinon": "4.1.3",
     "ts-node": "~3.0.4",
     "tslint": "~5.3.2",
     "typescript": "~2.3.3"

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.spec.ts
@@ -1,25 +1,140 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import * as sinon from 'sinon';
+import { async, inject, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { HttpModule, XHRBackend } from '@angular/http';
+import { MdCardModule, MdSelectModule, MdSnackBarModule, MdTooltipModule } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockBackend } from '@angular/http/testing';
 
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+import { ButtonComponent } from '../../layout/button/button.component';
 import { SendSkycoinComponent } from './send-skycoin.component';
+import { DateTimePipe } from '../../../pipes/date-time.pipe';
+import { SkyPipe } from '../../../pipes/sky.pipe';
+import { ApiService } from '../../../services/api.service';
+import { WalletService } from '../../../services/wallet.service';
 
 describe('SendSkycoinComponent', () => {
   let component: SendSkycoinComponent;
+  let mockBackend: MockBackend;
   let fixture: ComponentFixture<SendSkycoinComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SendSkycoinComponent ]
+      declarations: [
+        ButtonComponent,
+        DateTimePipe,
+        SendSkycoinComponent,
+        SkyPipe
+      ],
+      imports: [
+        HttpModule,
+        MdCardModule,
+        MdSelectModule,
+        MdSnackBarModule,
+        MdTooltipModule,
+        NgxDatatableModule,
+        NoopAnimationsModule,
+        ReactiveFormsModule,
+        RouterTestingModule
+      ],
+      providers: [
+        ApiService,
+        WalletService,
+        { provide: XHRBackend, useClass: MockBackend }
+      ]
     })
     .compileComponents();
   }));
 
-  beforeEach(() => {
+  beforeEach(inject([XHRBackend], (backend: MockBackend) => {
+    mockBackend = backend;
     fixture = TestBed.createComponent(SendSkycoinComponent);
     component = fixture.componentInstance;
+    component.ngOnInit();
     fixture.detectChanges();
+  }));
+
+  afterEach(() => {
+    fixture.destroy();
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('send should not make any backend call if wallet is not chosen', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    component.send();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should not make any backend call if address is not set', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    component.form.controls.wallet.setValue({
+      meta: { filename: 'test' },
+      balance: 1000000
+    });
+
+    component.send();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should not make any backend call if amount is not set', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    component.form.controls.wallet.setValue({
+      meta: { filename: 'test' },
+      balance: 1000000
+    });
+    component.form.controls.address.setValue('0xABC');
+
+    component.send();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should not make any backend call if amount exceeds balance', () => {
+    const backendCallSpy = sinon.spy();
+    mockBackend.connections.subscribe(backendCallSpy);
+
+    component.form.controls.wallet.setValue({
+      meta: { filename: 'test' },
+      balance: 1000000
+    });
+    component.form.controls.address.setValue('0xABC');
+    component.form.controls.amount.setValue(2);
+
+    component.send();
+
+    sinon.assert.notCalled(backendCallSpy);
+  });
+
+  it('send should make backend call if send form is valid', () => {
+    let request;
+    mockBackend.connections.subscribe((connection) => {
+      request = connection.request;
+    });
+
+    component.form.controls.wallet.setValue({
+      meta: { filename: 'test' },
+      balance: 1000000
+    });
+    component.form.controls.address.setValue('0xABC');
+    component.form.controls.amount.setValue(1);
+
+    component.send();
+
+    expect(request).toBeDefined();
+    expect(request.url).toBe('http://127.0.0.1:8620/wallet/spend?');
+    expect(request.getBody()).toBe('id=test&dst=0xABC&coins=1000000');
   });
 });

--- a/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
+++ b/src/gui/static/src/app/components/pages/send-skycoin/send-skycoin.component.ts
@@ -43,22 +43,27 @@ export class SendSkycoinComponent implements OnInit {
   }
 
   send() {
+    if (this.button.disabled()) {
+      return;
+    }
+
     this.button.setLoading();
-    const wallet_id = this.form.value.wallet.meta.filename;
-    this.walletService.sendSkycoin(wallet_id, this.form.value.address, this.form.value.amount * 1000000)
+
+    const walletId = this.form.value.wallet.meta.filename;
+    const addressToSend = this.form.value.address;
+    const amountToSend = this.form.value.amount * 1000000;
+
+    this.walletService.sendSkycoin(walletId, addressToSend, amountToSend)
       .delay(1000)
-      .subscribe(
-        response => {
-          this.resetForm();
-          this.button.setSuccess();
-        },
-        error => {
-          const config = new MdSnackBarConfig();
-          config.duration = 300000;
-          this.snackbar.open(error['_body'], null, config);
-          this.button.setError(error);
-        }
-      );
+      .subscribe(() => {
+        this.resetForm();
+        this.button.setSuccess();
+      }, error => {
+        const config = new MdSnackBarConfig();
+        config.duration = 300000;
+        this.snackbar.open(error['_body'], null, config);
+        this.button.setError(error);
+      });
   }
 
   private initForm() {

--- a/src/gui/static/src/app/components/pages/wallets/address-detail/wallet-detail.component.spec.ts
+++ b/src/gui/static/src/app/components/pages/wallets/address-detail/wallet-detail.component.spec.ts
@@ -1,20 +1,20 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { AddressDetailComponent } from './wallet-detail.component';
+import { WalletDetailComponent } from './wallet-detail.component';
 
 describe('AddressDetailComponent', () => {
-  let component: AddressDetailComponent;
-  let fixture: ComponentFixture<AddressDetailComponent>;
+  let component: WalletDetailComponent;
+  let fixture: ComponentFixture<WalletDetailComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ AddressDetailComponent ]
+      declarations: [ WalletDetailComponent ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AddressDetailComponent);
+    fixture = TestBed.createComponent(WalletDetailComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/gui/static/src/app/models/token.model.ts
+++ b/src/gui/static/src/app/models/token.model.ts
@@ -1,5 +1,5 @@
-interface TokenModel {
-    token: string;
-    label: string;
-    description: string;
-  }
+export interface TokenModel {
+  token: string;
+  label: string;
+  description: string;
+}

--- a/src/gui/static/src/app/services/purchase.service.ts
+++ b/src/gui/static/src/app/services/purchase.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/timeout';
+import { TokenModel } from '../models/token.model';
 
 @Injectable()
 export class PurchaseService {
@@ -16,7 +17,7 @@ export class PurchaseService {
 
   //
   private tellerNotice: Subject<any[]> = new BehaviorSubject<any[]>([]);
-  
+
   //buy types
   //private purchaseTokenTypes :Subject<any[]> = new BehaviorSubject<any[]>([]);
 
@@ -36,9 +37,9 @@ export class PurchaseService {
     console.log("address:"+address+", tokenType:"+tokenType);
     return this.post('bind', { address: address, tokenType: tokenType })
       .do(response => {
-     
+
         console.log(response);
-        if(response.code == 0) {      
+        if(response.code == 0) {
           //一个token可以有多个地址
             this.purchaseOrders.first().subscribe(orders => {
               let index = orders.findIndex(order => order.address === address && order.tokenType === tokenType);
@@ -58,9 +59,9 @@ export class PurchaseService {
             });
         }
       });
-      
+
   }
-  
+
   getCoinType(tokenType:string) {
     console.log(tokenType);
     if(tokenType == "skycoin") {
@@ -76,7 +77,7 @@ export class PurchaseService {
   scan(address: string,tokenType: string) {
     return this.get('status?address=' + address+"&tokenType="+tokenType).do(response => {
       if(response.code != 0) {
-        console.log(response);        
+        console.log(response);
         return;
       }
       this.purchaseOrders.first().subscribe(orders => {
@@ -94,7 +95,7 @@ export class PurchaseService {
         // Sort addresses ascending by creation date to match teller status response
         orders[index].addresses.sort((a, b) =>  b.created - a.created);
        // console.log(orders[index]);
-        
+
        // {"errmsg":"","code":0,"data":
        //{"statuses":[
       //{"seq":0,"update_at":1509881371,"address":"277BPWQYRVgUccUPZ3iCsJ9JrBwc4mEJ76","tokenType":"skycoin","status":"done"},
@@ -119,18 +120,18 @@ export class PurchaseService {
                 }
             }
           }
-          
+
           orders[index].addresses[idx].status = status.status
           orders[index].addresses[idx].updated =status.update_at;
         //  console.log( orders[index].addresses[idx]);
         }
-       
+
 
         this.updatePurchaseOrders(orders)
       });
     });
   }
-  
+
   alltokens(): Observable<TokenModel[]> {
     return this.purchaseTokenTypes.asObservable();
   }
@@ -140,15 +141,15 @@ export class PurchaseService {
         this.purchaseTokenTypes.first().subscribe(tokens=> {
             this.updateTokenTypes(tokens)
         });
-    });    
+    });
   }
-    
+
   getTellerNotice() {
     return this.get('teller').do(response=>{
         this.tellerNotice.first().subscribe(notice=> {
             this.tellerNotice.next(notice);
         });
-    });    
+    });
   }
 
   private get(url) {


### PR DESCRIPTION
As promised here is my own first PR for the Spaco :)

Currently user is able to press send button even if it looks like disabled + user can press send button once again even if previous send operation hasn't completed yet that may have quite bad consequences. `Send` is one of the critical parts of any crypto wallet so here shouldn't be any confusion at all.

I've fixed existing `SendSkycoinComponent` test and added few more. Also I started to slowly revive your Karma tests (looks like the majority of them are red). Let me know if it's useful or not for you.

Any bounty would be highly appreciated :)

My SPO address is: `BZ9N1mMLCzrpb2LpdvUHhuinqGWV9sgWwe`

Telegram: Alex/@oxycom
  