### PR TITLE
Allow Electron to do AIA fetching

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -21,8 +21,11 @@ global.eval = function() { throw new Error('bad!!'); }
 const defaultURL = 'http://127.0.0.1:8620/';
 let currentURL;
 
-// Force everything localhost, in case of a leak
-app.commandLine.appendSwitch('host-rules', 'MAP * 127.0.0.1, EXCLUDE teller.spaco.io');
+// Force everything localhost, in case of a leak, except for the teller API endpoint. We should also allow access to the
+// Comodo certificate authority since teller API server does not send a complete certificate chain and Chromium requires
+// an extra download of the intermediate certificate "COMODO RSA Domain Validation Secure Server CA" in order to
+// complete the chain. See https://bugs.chromium.org/p/chromium/issues/detail?id=799722 for more details.
+app.commandLine.appendSwitch('host-resolver-rules', 'MAP * 127.0.0.1, EXCLUDE teller.spaco.io, EXCLUDE *.comodoca.com');
 app.commandLine.appendSwitch('ssl-version-fallback-min', 'tls1.2');
 app.commandLine.appendSwitch('--no-proxy-server');
 app.setAsDefaultProtocolClient('spo');


### PR DESCRIPTION
As we've discussed on the Telegram, there is known issue in Spaco Wallet on Linux (at least) that prevents users from seeing all deposit buttons at the `Donation` tab.

The problem is that all requests to `https://teller.spaco.io/api/teller` fail, hence deposit buttons are not rendered. I've spent some time investigating that issue and figured out that problem is in [`host-rules` flag you pass to electron](https://github.com/spaco/spo/blob/master/electron/src/electron-main.js#L25) and the way Chromium uses this parameter.

In short `MAP * 127.0.0.1` rule is applied to all requests even browser internal ones, among these requests there is one particularly important - Authority Information Access fetching. Currently `https://teller.spaco.io` doesn't serve intermediate "COMODO RSA Domain Validation Secure Server CA" certificate (that's another issue, that you may want to fix at some point), so client (Electronium/Chromium) tries to fetch it from the Comodo servers (http://crt.comodoca.com/COMODORSADomainValidationSecureServerCA.crt) to build full certificate chain and fails since `crt.comodoca.com` is mapped to `127.0.0.1`.

I've filed [issue against Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=799722) to see if it's going to be fixed in Chromium or maybe it works as expected.

Moreover `host-rules` is considered as [`debug-only feature not supported for external use`](https://groups.google.com/a/chromium.org/forum/#!topic/net-dev/nsUyV30S5C8), so I've switched to `host-resolver-rules` that does the job well.

Obviously some of these issues will be fixed once `https://teller.spaco.io` starts serving both end and intermediate certificates, but I suspect we still need to allow browser to access Comodo CA server for other purposes (certificate revocation check etc.).

__P.S.__ I'll be tracking Chromium issue to see how it goes and whether Chromium will be doing something about that, even though they'll fix the issue, it will take some time and users can benefit from the workaround for the time being.

Aaand as always, bounty is not required, but highly appreciated :) 
My SPO address is: `BZ9N1mMLCzrpb2LpdvUHhuinqGWV9sgWwe`